### PR TITLE
[202311][warm/fast-reboot] Retain TRANSCEIVER_INFO/STATUS tables on deinit

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -781,6 +781,14 @@ def is_fast_reboot_enabled():
     fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
     return "true" in fastboot_enabled
 
+
+def is_warm_reboot_enabled():
+    warmstart = swsscommon.WarmStart()
+    warmstart.initialize("xcvrd", "pmon")
+    warmstart.checkWarmStart("xcvrd", "pmon", False)
+    is_warm_start = warmstart.isWarmStart()
+    return is_warm_start
+
 #
 # Helper classes ===============================================================
 #
@@ -1842,11 +1850,7 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
 
-        warmstart = swsscommon.WarmStart()
-        warmstart.initialize("xcvrd", "pmon")
-        warmstart.checkWarmStart("xcvrd", "pmon", False)
-        is_warm_start = warmstart.isWarmStart()
-
+        is_warm_start = is_warm_reboot_enabled()
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -2429,6 +2433,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
+        is_warm_fast_reboot = is_warm_reboot_enabled() or is_fast_reboot_enabled()
+
         # Delete all the information from DB and then exit
         port_mapping_data = port_mapping.get_port_mapping(self.namespaces)
         logical_port_list = port_mapping_data.logical_port_list
@@ -2439,15 +2445,18 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
 
+            intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index) if not is_warm_fast_reboot else None
+
             del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data,
-                                          self.xcvr_table_helper.get_intf_tbl(asic_index),
+                                          intf_tbl,
                                           self.xcvr_table_helper.get_dom_tbl(asic_index),
                                           self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
                                           self.xcvr_table_helper.get_pm_tbl(asic_index),
                                           self.xcvr_table_helper.get_firmware_info_tbl(asic_index))
-            delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
-            delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
+            if not is_warm_fast_reboot:
+                delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
+                delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
         del globals()['platform_chassis']
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Save TRANSCEIVER_INFO/STATUS tables on warm/fast-reboot.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The information in TRANSCEIVER_INFO/STATUS tables is required for orchagent to set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE=true on system startup.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Run fast/warm-reboot.

#### Additional Information (Optional)
