### PR TITLE
[xcvrd] add multi-ASIC support for warm boot scenarios

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -555,7 +555,7 @@ class TestXcvrdScript(object):
             restore_count if "WARM_RESTART_TABLE|syncd" in table else system_enabled
         )
 
-        with patch("xcvrd.xcvrd.daemon_base.db_connect", return_value=mock_db):
+        with patch("xcvrd.xcvrd_utilities.common.daemon_base.db_connect", return_value=mock_db):
             assert is_syncd_warm_restore_complete() == expected
 
     def test_is_syncd_warm_restore_complete_invalid_restore_count(self):
@@ -565,9 +565,32 @@ class TestXcvrdScript(object):
             "abc" if "WARM_RESTART_TABLE|syncd" in table else None
         )
 
-        with patch("xcvrd.xcvrd.daemon_base.db_connect", return_value=mock_db):
+        with patch("xcvrd.xcvrd_utilities.common.daemon_base.db_connect", return_value=mock_db):
             result = is_syncd_warm_restore_complete()
             assert result is False
+
+    @pytest.mark.parametrize(
+        "namespace, restore_count, expected",
+        [
+            ('', 1, True),              # Default namespace
+            ('asic0', 1, True),         # Multi-ASIC namespace asic0
+            ('asic1', 1, True),         # Multi-ASIC namespace asic1
+            ('asic0', 0, False),        # No warm restore for asic0
+            ('asic1', 0, False),        # No warm restore for asic1
+        ]
+    )
+    def test_is_syncd_warm_restore_complete_with_namespace(self, namespace, restore_count, expected):
+        """Test is_syncd_warm_restore_complete with different namespaces for multi-ASIC support"""
+        mock_db = MagicMock()
+        mock_db.hget.side_effect = lambda table, key: (
+            restore_count if "WARM_RESTART_TABLE|syncd" in table else None
+        )
+
+        with patch("xcvrd.xcvrd_utilities.common.daemon_base.db_connect", return_value=mock_db) as mock_connect:
+            result = is_syncd_warm_restore_complete(namespace)
+            assert result == expected
+            # Verify db_connect was called with the correct namespace
+            mock_connect.assert_called_with("STATE_DB", namespace=namespace)
 
     def test_post_port_dom_sensor_info_to_db(self):
         def mock_get_transceiver_dom_sensor_real_value(physical_port):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -311,7 +311,11 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
 
-        is_warm_start = common.is_syncd_warm_restore_complete()
+        # Pre-fetch warm start status for all namespaces/ASICs
+        warm_start_status = {}
+        for namespace in self.namespaces:
+            warm_start_status[namespace] = common.is_syncd_warm_restore_complete(namespace)
+
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -323,6 +327,11 @@ class SfpStateUpdateTask(threading.Thread):
             if asic_index is None:
                 helper_logger.log_warning("Got invalid asic index for {}, ignored while posting SFP info during boot-up".format(logical_port_name))
                 continue
+
+            # Get warm start status for this ASIC's namespace
+            namespace = common.get_namespace_from_asic_id(asic_index)
+            is_warm_start = warm_start_status.get(namespace, False)
+
             rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
             if rc != SFP_EEPROM_NOT_READY:
                 if is_warm_start == False:
@@ -1067,7 +1076,11 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
-        is_warm_fast_reboot = common.is_syncd_warm_restore_complete() or common.is_fast_reboot_enabled()
+        # Pre-fetch warm/fast reboot status for all namespaces/ASICs
+        is_fast_reboot = common.is_fast_reboot_enabled()
+        warm_fast_reboot_status = {}
+        for namespace in self.namespaces:
+            warm_fast_reboot_status[namespace] = common.is_syncd_warm_restore_complete(namespace) or is_fast_reboot
 
         # Delete all the information from DB and then exit
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)
@@ -1078,6 +1091,10 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             if asic_index is None:
                 helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
+
+            # Get warm/fast reboot status for this ASIC's namespace
+            namespace = common.get_namespace_from_asic_id(asic_index)
+            is_warm_fast_reboot = warm_fast_reboot_status.get(namespace, False)
 
             # Skip deleting intf_tbl for avoiding OA to trigger Tx disable signal
             # due to TRANSCEIVER_INFO table deletion during xcvrd shutdown/crash


### PR DESCRIPTION
- Modified is_syncd_warm_restore_complete() to accept namespace parameter to connect to the correct STATE_DB for each ASIC
- Added get_namespace_from_asic_id() helper function to convert ASIC ID to namespace string
- Updated _post_port_sfp_info_and_dom_thr_to_db_once() to pre-fetch warm start status for all namespaces and check per-ASIC during port processing
- Updated deinit() to check warm/fast reboot status per-ASIC namespace
- Added unit tests for namespace-aware warm restore checking

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
